### PR TITLE
Add additional ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ config/environment.json
 *.egg-info
 *.DS_Store
 
+# PyCharm metadata
+.idea/
+
+# Mercurial metadata, for people that use git *only* for pushing to Github
+.hg/
+.hgignore


### PR DESCRIPTION
Add additional ignores

To prevent upstream pollution, I have to add some new ignores.

.gitignore:
- PyCharm metadata, for PyCharm-using devs.
- Mercurial metadata, for people (like me) that use Git _only_ to push
  to Github, and Mercurial for daily dev.
